### PR TITLE
Escape asterisk and exclamation mark for both markers to fix html and php commenting.

### DIFF
--- a/autoload/commentor.vim
+++ b/autoload/commentor.vim
@@ -8,8 +8,8 @@ function! commentor#CommentToggle(type, ...)
   let cmt_markers = split(substitute(substitute(&commentstring, '\S\zs%s', ' %s', ''), '%s\ze\S', '%s ', ''), '%s', 1)
 
   " Get space-trimmed LHS and RHS comment-markers
-  let lhs_cmt_marker = substitute(cmt_markers[0], ' ', '', '')
-  let rhs_cmt_marker = substitute(cmt_markers[1], ' ', '', '')
+  let lhs_cmt_marker = escape(substitute(cmt_markers[0], ' ', '', ''), '*')
+  let rhs_cmt_marker = escape(substitute(cmt_markers[1], ' ', '', ''), '*')
 
   " Check if the first line is commented
   if match(getline('.'), lhs_cmt_marker) == 0


### PR DESCRIPTION
This plugin works great, especially on many lines, where others are really slow. I tried it initially in javascript, and it works ok. Later i tested it in php and html, and i got an error. Figured out that asterisk and exclamation mark are not escaped, so it treats asterisk as part of regex. Same for the html exclamation mark. This should fix it.